### PR TITLE
DAOS-4254 test: Improve teardown and logging in dfuse tests. (#2037)

### DIFF
--- a/ftest.sh
+++ b/ftest.sh
@@ -262,6 +262,7 @@ cat <<EOF > ~/.config/avocado/avocado.conf
 logs_dir = $DAOS_BASE/install/lib/daos/TESTING/ftest/avocado/job-results
 
 [sysinfo.collectibles]
+files = \$HOME/.config/avocado/sysinfo/files
 # File with list of commands that will be executed and have their output
 # collected
 commands = \$HOME/.config/avocado/sysinfo/commands
@@ -272,6 +273,10 @@ cat <<EOF > ~/.config/avocado/sysinfo/commands
 ps axf
 dmesg
 df -h
+EOF
+
+cat <<EOF > ~/.config/avocado/sysinfo/files
+/proc/mounts
 EOF
 
 # apply patch for https://github.com/avocado-framework/avocado/pull/3076/

--- a/src/tests/ftest/soak/soak.py
+++ b/src/tests/ftest/soak/soak.py
@@ -405,7 +405,8 @@ class Soak(TestWithServers):
             pool (obj):   TestPool obj
         """
         # Get Dfuse params
-        self.dfuse = Dfuse(self.hostlist_clients, self.tmp, self.basepath)
+        self.dfuse = Dfuse(self.hostlist_clients, self.tmp,
+                           dfuse_env=self.basepath)
         self.dfuse.get_params(self)
 
         # update dfuse params

--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -275,6 +275,8 @@ def include_local_host(hosts):
     if hosts is None:
         hosts = [local_host]
     elif local_host not in hosts:
+        # Take a copy of hosts to avoid modifying-in-place
+        hosts = list(hosts)
         hosts.append(local_host)
     return hosts
 

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -47,7 +47,7 @@ class BasicParameter(object):
         """
         self.value = value if value is not None else default
         self._default = default
-        self.log = getLogger(__name__)
+        self.log = getLogger(self.__class__.__name__)
 
     def __str__(self):
         """Convert this BasicParameter into a string.
@@ -147,7 +147,7 @@ class ObjectWithParameters(object):
             namespace (str): yaml namespace (path to parameters)
         """
         self.namespace = namespace
-        self.log = getLogger(__name__)
+        self.log = getLogger(self.__class__.__name__)
 
     def get_attribute_names(self, attr_type=None):
         """Get a sorted list of the names of the attr_type attributes.

--- a/src/tests/ftest/util/configuration_utils.py
+++ b/src/tests/ftest/util/configuration_utils.py
@@ -219,7 +219,6 @@ class ConfigurationParameters(ObjectWithParameters):
         super(ConfigurationParameters, self).__init__(namespace + name + "/*")
         self.name = name
         self._config_data = data
-        self.log = getLogger(__name__)
 
         # Define the yaml entries that define the configuration
         #  - Make sure to add any new parameter names defined here in the

--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -18,13 +18,14 @@
   portions thereof marked with this legend must also reproduce the markings.
 """
 from __future__ import print_function
-import general_utils
+import time
 
 from command_utils import ExecutableCommand, EnvironmentVariables
 from command_utils import CommandFailure, FormattedParameter
 from ClusterShell.NodeSet import NodeSet
 from server_utils import AVOCADO_FILE
 
+import general_utils
 
 class DfuseCommand(ExecutableCommand):
     """Defines a object representing a dfuse command."""
@@ -84,7 +85,7 @@ class DfuseCommand(ExecutableCommand):
 class Dfuse(DfuseCommand):
     """Class defining an object of type DfuseCommand"""
 
-    def __init__(self, hosts, tmp, dfuse_env=False):
+    def __init__(self, hosts, tmp, dfuse_env=False, log_file=None):
         """Create a dfuse object"""
         super(Dfuse, self).__init__("/run/dfuse/*", "dfuse")
 
@@ -92,6 +93,7 @@ class Dfuse(DfuseCommand):
         self.hosts = hosts
         self.tmp = tmp
         self.dfuse_env = dfuse_env
+        self.log_file = log_file
 
     def __del__(self):
         """Destroy Dfuse object and stop dfuse """
@@ -113,7 +115,7 @@ class Dfuse(DfuseCommand):
         if not dir_exists:
             cmd = "mkdir -p {}".format(self.mount_dir.value)
             ret_code = general_utils.pcmd(self.hosts, cmd, timeout=30)
-            if 0 not in ret_code:
+            if len(ret_code) > 1 or 0 not in ret_code:
                 error_hosts = NodeSet(
                     ",".join(
                         [str(node_set) for code, node_set in ret_code.items()
@@ -122,35 +124,66 @@ class Dfuse(DfuseCommand):
                     "Error creating the {} dfuse mount point on the following "
                     "hosts: {}".format(self.mount_dir.value, error_hosts))
 
-    def remove_mount_point(self):
+    def remove_mount_point(self, fail=True):
         """Remove dfuse directory
         Raises:
             CommandFailure: In case of error deleting directory
+
+        Try once with a simple rmdir which should succeed, if this
+        does not then try again with rm -rf, but still raise an error
         """
         # raise exception if mount point not specified
         if self.mount_dir.value is None:
             raise CommandFailure("Mount point not specified, "
                                  "check test yaml file")
 
-        dir_exists, _ = general_utils.check_file_exists(
+        dir_exists, clean_nodes = general_utils.check_file_exists(
             self.hosts, self.mount_dir.value, directory=True)
         if dir_exists:
+
+            target_nodes = list(self.hosts)
+            if clean_nodes:
+                target_nodes.remove(clean_nodes)
+
+            cmd = "rmdir {}".format(self.mount_dir.value)
+            ret_code = general_utils.pcmd(target_nodes, cmd, timeout=30)
+            if len(ret_code) == 1 and 0 in ret_code:
+                return
+
+            failed_nodes = NodeSet(",".join(
+                [str(node_set) for code, node_set in ret_code.items()
+                 if code != 0]))
+
             cmd = "rm -rf {}".format(self.mount_dir.value)
-            ret_code = general_utils.pcmd(self.hosts, cmd, timeout=30)
-            if 0 not in ret_code:
+            ret_code = general_utils.pcmd(failed_nodes, cmd, timeout=30)
+            if len(ret_code) > 1 or 0 not in ret_code:
                 error_hosts = NodeSet(
                     ",".join(
                         [str(node_set) for code, node_set in ret_code.items()
                          if code != 0]))
+                if fail:
+                    raise CommandFailure(
+                        "Error removing the {} dfuse mount point with rm on "
+                        "the following hosts: {}".format(self.mount_dir.value,
+                                                         error_hosts))
+            if fail:
                 raise CommandFailure(
-                    "Error removing the {} dfuse mount point on the following "
-                    "hosts: {}".format(self.mount_dir.value, error_hosts))
+                    "Error removing the {} dfuse mount point with rmdir on the "
+                    "following hosts: {}".format(self.mount_dir.value,
+                                                 failed_nodes))
 
     def run(self):
         """ Run the dfuse command.
         Raises:
             CommandFailure: In case dfuse run command fails
         """
+
+        self.log.info('Starting dfuse at %s', self.mount_dir.value)
+
+        # Allow Dfuse instances without a logfile so that they can
+        # call get_default_env(), but do not launch dfuse itself
+        # without one, as that means logs will be missing from the test.
+        assert self.log_file is not None
 
         # create dfuse dir if does not exist
         self.create_mount_point()
@@ -160,7 +193,7 @@ class Dfuse(DfuseCommand):
         ret_code = general_utils.pcmd(self.hosts, env + self.__str__(),
                                       timeout=30)
         # check for any failures
-        if 0 not in ret_code:
+        if len(ret_code) > 1 or 0 not in ret_code:
             error_hosts = NodeSet(
                 ",".join(
                     [str(node_set) for code, node_set in ret_code.items()
@@ -173,21 +206,36 @@ class Dfuse(DfuseCommand):
         """Stop dfuse
         Raises:
             CommandFailure: In case dfuse stop fails
-        """
 
-        cmd = "if [ -x '$(command -v fusermount)' ]; "
-        cmd += "then fusermount -u {0}; else fusermount3 -u {0}; fi".\
+        Try to stop dfuse.  Try once nicely by using fusermount, then if that
+        fails try to pkill it to see if that works.  Abort based on the result
+        of the fusermount, as if pkill is necessary then dfuse itself has
+        not worked correctly.
+
+        Finally, try and remove the mount point, and that itself should work.
+        """
+        self.log.info('Stopping dfuse at %s', self.mount_dir.value)
+
+        if self.mount_dir.value is None:
+            return
+        umount_cmd = "if [ -x '$(command -v fusermount)' ]; "
+        umount_cmd += "then fusermount -u {0}; else fusermount3 -u {0}; fi".\
                format(self.mount_dir.value)
-        ret_code = general_utils.pcmd(self.hosts, cmd, timeout=30)
-        self.remove_mount_point()
-        if 0 not in ret_code:
+        ret_code = general_utils.pcmd(self.hosts, umount_cmd, timeout=30)
+        if len(ret_code) > 1 or 0 not in ret_code:
             error_hosts = NodeSet(
                 ",".join(
                     [str(node_set) for code, node_set in ret_code.items()
                      if code != 0]))
+            cmd = "pkill dfuse --signal KILL"
+            general_utils.pcmd(error_hosts, cmd, timeout=30)
+            general_utils.pcmd(error_hosts, umount_cmd, timeout=30)
+            self.remove_mount_point(fail=False)
             raise CommandFailure(
                 "Error stopping dfuse on the following hosts: {}".format(
                     error_hosts))
+        time.sleep(2)
+        self.remove_mount_point()
 
     def get_default_env(self):
 
@@ -200,7 +248,9 @@ class Dfuse(DfuseCommand):
         # obtain any env variables to be exported
         env = EnvironmentVariables()
         env["CRT_ATTACH_INFO_PATH"] = self.tmp
-        env["DAOS_SINGLETON_CLI"] = 1
+
+        if self.log_file:
+            env["D_LOG_FILE"] = self.log_file
 
         if self.dfuse_env:
             try:

--- a/src/tests/ftest/util/fio_test_base.py
+++ b/src/tests/ftest/util/fio_test_base.py
@@ -26,7 +26,7 @@ from __future__ import print_function
 import subprocess
 
 from ClusterShell.NodeSet import NodeSet
-from apricot import TestWithServers
+from apricot import TestWithServers, get_log_file
 from test_utils_pool import TestPool
 from fio_utils import FioCommand
 from command_utils import CommandFailure
@@ -54,9 +54,6 @@ class FioBase(TestWithServers):
 
         # Start the servers and agents
         super(FioBase, self).setUp()
-
-        # removing runner node from hostlist_client, only need one client node.
-        self.hostlist_clients = self.hostlist_clients[:-1]
 
         # Get the parameters for Fio
         self.fio_cmd = FioCommand()
@@ -111,7 +108,9 @@ class FioBase(TestWithServers):
     def _start_dfuse(self):
         """Create a DfuseCommand object to start dfuse."""
         # Get Dfuse params
-        self.dfuse = Dfuse(self.hostlist_clients, self.tmp, self.basepath)
+        self.dfuse = Dfuse(self.hostlist_clients, self.tmp,
+                           log_file=get_log_file(self.client_log),
+                           dfuse_env=self.basepath)
         self.dfuse.get_params(self)
 
         # update dfuse params

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -119,7 +119,9 @@ class IorTestBase(TestWithServers):
     def start_dfuse(self):
         """Create a DfuseCommand object to start dfuse."""
         # Get Dfuse params
-        self.dfuse = Dfuse(self.hostlist_clients, self.tmp, True)
+        self.dfuse = Dfuse(self.hostlist_clients, self.tmp,
+                           log_file=get_log_file(self.client_log),
+                           dfuse_env=True)
         self.dfuse.get_params(self)
 
         # update dfuse params

--- a/src/tests/ftest/util/mdtest_test_base.py
+++ b/src/tests/ftest/util/mdtest_test_base.py
@@ -67,10 +67,14 @@ class MdtestBase(TestWithServers):
         # Until DAOS-3320 is resolved run IOR for POSIX
         # with single client node
         if self.mdtest_cmd.api.value == "POSIX":
+            self.log.info("Restricting mdtest to one node")
             self.hostlist_clients = [self.hostlist_clients[0]]
             self.hostfile_clients = write_host_file.write_host_file(
                 self.hostlist_clients, self.workdir,
                 self.hostfile_clients_slots)
+
+        self.log.info('Clients %s', self.hostlist_clients)
+        self.log.info('Servers %s', self.hostlist_servers)
 
     def tearDown(self):
         """Tear down each test case."""
@@ -117,7 +121,10 @@ class MdtestBase(TestWithServers):
     def _start_dfuse(self):
         """Create a DfuseCommand object to start dfuse."""
         # Get Dfuse params
-        self.dfuse = Dfuse(self.hostlist_clients, self.tmp, True)
+        self.dfuse = Dfuse(self.hostlist_clients,
+                           self.tmp,
+                           log_file=get_log_file(self.client_log),
+                           dfuse_env=True)
         self.dfuse.get_params(self)
 
         # update dfuse params

--- a/src/tests/ftest/util/test_utils_base.py
+++ b/src/tests/ftest/util/test_utils_base.py
@@ -88,7 +88,6 @@ class TestDaosApiBase(ObjectWithParameters):
         super(TestDaosApiBase, self).__init__(namespace)
         self.cb_handler = cb_handler
         self.debug = BasicParameter(None, False)
-        self.log = getLogger(__name__)
 
     def _log_method(self, name, kwargs):
         """Log the method call with its arguments.


### PR DESCRIPTION
PR's text:
```
Add rudimentry logging.
Do not attempt to remove undefined directories.
Use rmdir rather than rm -rf initially on mount point
Try to kill dfuse with pkill on nodes where fusermount fails, and then clean up with a second fusermount call.
If fusermount fails abort before trying to remove the directory.
Correct the use of ret_code so that errors are properly logged
Add the contents of /proc/mounts to sysinfo.
Collect the logging from dfuse so it's saved in Jenkins.
Do not add the local node to the client list.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
```

link to original PR: `https://github.com/daos-stack/daos/pull/2274`