### PR TITLE
DAOS-3909 dtx: new DAOS API - daos_tx_restart

### DIFF
--- a/src/client/api/tx.c
+++ b/src/client/api/tx.c
@@ -128,13 +128,7 @@ daos_tx_hdl2epoch(daos_handle_t th, daos_epoch_t *epoch)
 }
 
 int
-daos_tx_local2global(daos_handle_t th, d_iov_t *glob)
+daos_tx_restart(daos_handle_t th)
 {
-	return -DER_NOSYS;
-}
-
-int
-daos_tx_global2local(daos_handle_t coh, d_iov_t glob, daos_handle_t *th)
-{
-	return -DER_NOSYS;
+	return dc_tx_restart(th);
 }

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -358,6 +358,7 @@ int dc_tx_local_open(daos_handle_t coh, daos_epoch_t epoch,
 		     uint32_t flags, daos_handle_t *th);
 int dc_tx_local_close(daos_handle_t th);
 int dc_tx_hdl2epoch(daos_handle_t th, daos_epoch_t *epoch);
+int dc_tx_restart(daos_handle_t th);
 
 /** Decode shard number from enumeration anchor */
 static inline uint32_t

--- a/src/include/daos_api.h
+++ b/src/include/daos_api.h
@@ -133,12 +133,24 @@ daos_tx_close(daos_handle_t th, daos_event_t *ev);
  * Return epoch associated with the transaction handle.
  *
  * \param[in]	th	Transaction handle.
- * \param[out]	th	Returned epoch value.
+ * \param[out]	epoch	Returned epoch value.
  *
  * \return		0 if Success, negative if failed.
  */
 DAOS_API int
 daos_tx_hdl2epoch(daos_handle_t th, daos_epoch_t *epoch);
+
+/**
+ * Restart the transaction with newer epoch. That clean up its former
+ * non-committed modifications. The transaction can be restarted only
+ * when it is in open or failed status.
+ *
+ * \param[in]	th	Transaction handle.
+ *
+ * \return		0 if Success, negative if failed.
+ */
+DAOS_API int
+daos_tx_restart(daos_handle_t th);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
PR's text:
```
DAOS_API int
daos_tx_restart(daos_handle_t th);

It allows the application to restart the transaction with
newer epoch. That will clean up its former non-committed
modifications. The transaction can be restarted only when
it is in open or failed status.

Signed-off-by: Fan Yong <fan.yong@intel.com>
```

link to original PR: `https://github.com/daos-stack/daos/pull/2276`