### PR TITLE
DAOS-3545 iv: undo temporary workaround for some iv failures

### DIFF
--- a/src/iosrv/server_iv.c
+++ b/src/iosrv/server_iv.c
@@ -828,11 +828,7 @@ ds_iv_done(crt_iv_namespace_t ivns, uint32_t class_id,
 	struct iv_cb_info	*cb_info = cb_arg;
 	int			ret = 0;
 
-	/* FIXME: Temporarily ignore certain IV errors. See DAOS-3545. */
-	if (rc == -DER_UNREACH || rc == -DER_TIMEDOUT)
-		cb_info->result = 0;
-	else
-		cb_info->result = rc;
+	cb_info->result = rc;
 
 	if (cb_info->opc == IV_FETCH && cb_info->value) {
 		struct ds_iv_entry	*entry;


### PR DESCRIPTION
PR's text:
```
Cherry pick of PR #2285 from daos master to release/0.9 branch.

PR #1276 that updated the CaRT used in DAOS added a temporary
workaround to ds_iv_done() to ignore certain RPC errors. With this
change, and because of the DAOS improvements and newer CaRT versions
integrated since that time, this workaround can now be removed.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>
```

link to original PR: `https://github.com/daos-stack/daos/pull/2304`