### PR TITLE
CORCI-843 buid: Skip build and test for doc-only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ def skip_stage(String stage) {
     return commitPragma(pragma: 'Skip-' + stage).contains('true')
 }
 
-def daos_branch = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
+daos_branch = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
 def arch = ""
 def sanitized_JOB_NAME = JOB_NAME.toLowerCase().replaceAll('/', '-').replaceAll('%2f', '-')
 


### PR DESCRIPTION
PR's text:
```
Also skip checkpatch.

A few other enhancements while we're in here:
- Skip-build: true implies Skip-test: true
- make a generic skip() test function
- remove unused/obsoleted inline Skip-* checks
- use Jenkinsfile idoms such as environment instead of expression {
  env.<variable> ... }
- take advantage of env.CHANGE_TARGET instead of hardcoding the target
  into the Jenkinsfile
- don't skip build on landing to branch even if Skip-build: true is in
  the commit message
  - every lastSuccessfulBuild of a branch needs to have build artifacts
    in it

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>
```

link to original PR: `https://github.com/daos-stack/daos/pull/2314`