### PR TITLE
DAOS-4263 test: evt_ctl and btree tests cleanup

### DIFF
--- a/src/common/tests/btree.c
+++ b/src/common/tests/btree.c
@@ -79,6 +79,10 @@ struct ik_rec {
 	umem_off_t	ir_val_off;
 };
 
+char	**test_group_args;
+int	test_group_start;
+int	test_group_stop;
+
 #define IK_TREE_CLASS	100
 #define POOL_NAME "/mnt/daos/btree-test"
 #define POOL_SIZE ((1024 * 1024 * 1024ULL))
@@ -877,108 +881,6 @@ ik_btr_drain(void **state)
 	D_FREE(arr);
 }
 
-static int
-run_btree_open_create_test(void)
-{
-	static const struct CMUnitTest btree_open_create_test[] = {
-		{ "BTR001: btree_open_create test", ik_btr_open_create,
-			NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("btree open create test",
-					btree_open_create_test, NULL, NULL);
-}
-
-static int
-run_btree_close_destroy_test(void)
-{
-	static const struct CMUnitTest btree_close_destroy_test[] = {
-		{ "BTR002: btree_close_destroy test", ik_btr_close_destroy,
-			NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("btree close destroy test",
-					btree_close_destroy_test, NULL, NULL);
-}
-
-static int
-run_btree_query_test(void)
-{
-	static const struct CMUnitTest btree_query_test[] = {
-		{ "BTR003: btree_query test", ik_btr_query,
-			NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("btree query test",
-					btree_query_test, NULL, NULL);
-}
-
-static int
-run_btree_iter_test(void)
-{
-	static const struct CMUnitTest btree_iterate_test[] = {
-		{ "BTR004: btree_iterate test", ik_btr_iterate,
-			NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("btree iterate test",
-					btree_iterate_test, NULL, NULL);
-}
-
-static int
-run_btree_batch_oper_test(void)
-{
-	static const struct CMUnitTest btree_batch_oper_test[] = {
-		{ "BTR005: btree_batch_oper test", ik_btr_batch_oper,
-			NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("btree batch oper test",
-					btree_batch_oper_test, NULL, NULL);
-}
-
-static int
-run_btree_perf_test(void)
-{
-	static const struct CMUnitTest btree_perf_test[] = {
-		{ "BTR006: btree_perf test", ik_btr_perf, NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("btree perf test",
-					btree_perf_test, NULL, NULL);
-}
-
-static int
-run_btree_kv_operate_test(void)
-{
-	static const struct CMUnitTest btree_kv_operate_test[] = {
-		{ "BTR007: btree_kv_operate test",
-			ik_btr_kv_operate, NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("btree kv operate test",
-				btree_kv_operate_test, NULL, NULL);
-}
-
-static int
-run_btree_drain_test(void)
-{
-	static const struct CMUnitTest btree_drain_test[] = {
-		{ "BTR008: btree_drain test", ik_btr_drain, NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("btree drain test",
-				btree_drain_test, NULL, NULL);
-}
-
 static struct option btr_ops[] = {
 	{ "create",	required_argument,	NULL,	'C'	},
 	{ "destroy",	no_argument,		NULL,	'D'	},
@@ -997,6 +899,90 @@ static struct option btr_ops[] = {
 	{ NULL,		0,			NULL,	0	},
 };
 
+static void
+ts_group(void ** state){
+	int	opt = 0;
+	void	**st = NULL;
+	while ((opt = getopt_long(test_group_stop-test_group_start+1,
+				  test_group_args+test_group_start,
+				  "tmC:Deocqu:d:r:f:i:b:p:",
+				  btr_ops,
+				  NULL)) != -1) {
+		tst_fn_val.optval = optarg;
+		tst_fn_val.input = true;
+
+		switch (opt) {
+		case 'C':
+			ik_btr_open_create(st);
+			break;
+		case 'D':
+			tst_fn_val.input = true;
+			ik_btr_close_destroy(st);
+			break;
+		case 'o':
+			tst_fn_val.input = false;
+			tst_fn_val.optval = NULL;
+			ik_btr_open_create(st);
+			break;
+		case 'c':
+			tst_fn_val.input = false;
+			ik_btr_close_destroy(st);
+			break;
+		case 'e':
+			ik_btr_drain(st);
+			break;
+		case 'q':
+			ik_btr_query(st);
+			break;
+		case 'u':
+			tst_fn_val.opc = BTR_OPC_UPDATE;
+			ik_btr_kv_operate(st);
+			break;
+		case 'f':
+			tst_fn_val.opc = BTR_OPC_LOOKUP;
+			ik_btr_kv_operate(st);
+			break;
+		case 'd':
+			tst_fn_val.opc = BTR_OPC_DELETE;
+			ik_btr_kv_operate(st);
+			break;
+		case 'r':
+			tst_fn_val.opc = BTR_OPC_DELETE_RETAIN;
+			ik_btr_kv_operate(st);
+			break;
+		case 'i':
+			ik_btr_iterate(st);
+			break;
+		case 'b':
+			ik_btr_batch_oper(st);
+			break;
+		case 'p':
+			ik_btr_perf(st);
+			break;
+		default:
+			D_PRINT("Unsupported command %c\n", opt);
+		case 'm':
+		case 't':
+			/* handled previously */
+			break;
+		}
+	}
+}
+
+static int
+run_cmd_line_test(char* test_name, char** args, int start_idx, int stop_idx)
+{
+	const struct CMUnitTest btree_test[] = {
+		{test_name, ts_group, NULL, NULL},
+	};
+	
+	test_group_args = args;
+	test_group_start = start_idx;
+	test_group_stop = stop_idx;
+
+	return cmocka_run_group_tests_name("Btree group of tests", btree_test, NULL, NULL);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -1004,6 +990,9 @@ main(int argc, char **argv)
 	int		rc = 0;
 	int		opt;
 	int		dynamic_flag = 0;
+	int		start_idx;
+	char		*test_name;
+	int		stop_idx;
 
 	d_register_alt_assert(mock_assert);
 
@@ -1017,7 +1006,16 @@ main(int argc, char **argv)
 	if (rc != 0)
 		return rc;
 
-	optind = 0;
+	if (argc == 1) {
+		print_message("Invalid format.\n");
+		return -1;
+	}
+
+	if(strcmp(argv[1], "--start-test") == 0){
+		optind = 2;
+	} else {
+		optind = 0;
+	}
 
 	/* Check for -m option first */
 	while ((opt = getopt_long(argc, argv, "tmC:Deocqu:d:r:f:i:b:p:",
@@ -1051,70 +1049,15 @@ main(int argc, char **argv)
 
 	/* start over */
 	optind = 0;
-
-	while ((opt = getopt_long(argc, argv, "tmC:Deocqu:d:r:f:i:b:p:",
-				  btr_ops, NULL)) != -1) {
-		tst_fn_val.optval = optarg;
-		tst_fn_val.input = true;
-		switch (opt) {
-		case 'C':
-			rc = run_btree_open_create_test();
-			break;
-		case 'D':
-			tst_fn_val.input = true;
-			rc = run_btree_close_destroy_test();
-			break;
-		case 'o':
-			tst_fn_val.input = false;
-			tst_fn_val.optval = NULL;
-			rc = run_btree_open_create_test();
-			break;
-		case 'c':
-			tst_fn_val.input = false;
-			rc = run_btree_close_destroy_test();
-			break;
-		case 'e':
-			rc = run_btree_drain_test();
-			break;
-		case 'q':
-			rc = run_btree_query_test();
-			break;
-		case 'u':
-			tst_fn_val.opc = BTR_OPC_UPDATE;
-			rc = run_btree_kv_operate_test();
-			break;
-		case 'f':
-			tst_fn_val.opc = BTR_OPC_LOOKUP;
-			rc = run_btree_kv_operate_test();
-			break;
-		case 'd':
-			tst_fn_val.opc = BTR_OPC_DELETE;
-			rc = run_btree_kv_operate_test();
-			break;
-		case 'r':
-			tst_fn_val.opc = BTR_OPC_DELETE_RETAIN;
-			rc = run_btree_kv_operate_test();
-			break;
-		case 'i':
-			rc = run_btree_iter_test();
-			break;
-		case 'b':
-			rc = run_btree_batch_oper_test();
-			break;
-		case 'p':
-			rc = run_btree_perf_test();
-			break;
-		default:
-			D_PRINT("Unsupported command %c\n", opt);
-		case 'm':
-		case 't':
-			/* handled previously */
-			rc = 0;
-			break;
-		}
-		if (rc != 0)
-			break;
+	stop_idx = argc-1;
+	if(strcmp(argv[1], "--start-test") != 0){
+		start_idx = 0;
+		test_name = "Btree testing tool";
+	} else {
+		start_idx = 2;
+		test_name = argv[start_idx];
 	}
+	rc = run_cmd_line_test(test_name, argv, start_idx, stop_idx);
 	daos_debug_fini();
 	rc += utest_utx_destroy(ik_utx);
 	if (rc != 0)

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -100,6 +100,11 @@ struct test_arg {
 	char			*ta_pool_name;
 };
 
+/* variables for test group */
+char		**test_group_args;
+int		test_group_start;
+int		test_group_stop;
+
 static int
 ts_evt_bio_free(struct umem_instance *umm, struct evt_desc *desc,
 		daos_size_t nob, void *args)
@@ -2040,113 +2045,6 @@ test_evt_root_deactivate_bug(void **state)
 	rc = evt_destroy(toh);
 	assert_int_equal(rc, 0);
 }
-static int
-run_create_test(void)
-{
-	static const struct CMUnitTest evt_create[] = {
-		{ "EVT001: evt_create", ts_open_create, NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("evtree create test", evt_create,
-					   NULL, NULL);
-}
-
-static int
-run_destroy_test(void)
-{
-	static const struct CMUnitTest evt_destroy[] = {
-		{ "EVT002: evt_destroy", ts_close_destroy, NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("evtree destroy test", evt_destroy,
-						NULL, NULL);
-}
-
-static int
-run_add_test(void)
-{
-	static const struct CMUnitTest evt_add_rect[] = {
-		{ "EVT003: evt_add_rect", ts_add_rect, NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("evtree add test", evt_add_rect,
-						NULL, NULL);
-}
-
-static int
-run_many_add_test(void)
-{
-	static const struct CMUnitTest evt_many_add[] = {
-		{ "EVT004: evt_many_add", ts_many_add, NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("evtree many add test",
-						evt_many_add, NULL, NULL);
-}
-
-static int
-run_find_rect_test(void)
-{
-	static const struct CMUnitTest evt_find_rect[] = {
-		{ "EVT005: evt_find_rect", ts_find_rect, NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("evtree find rect test",
-						evt_find_rect, NULL, NULL);
-}
-
-static int
-run_list_rect_test(void)
-{
-	static const struct CMUnitTest evt_list_rect[] = {
-		{ "EVT006: evt_list_rect", ts_list_rect, NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("evtree list rect test",
-						evt_list_rect, NULL, NULL);
-}
-
-static int
-run_delete_rect_test(void)
-{
-	static const struct CMUnitTest evt_delete_rect[] = {
-		{ "EVT007: evt_delete_rect", ts_delete_rect, NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("evtree delete rect test",
-						evt_delete_rect, NULL, NULL);
-}
-
-static int
-run_tree_debug_test(void)
-{
-	static const struct CMUnitTest evt_tree_debug[] = {
-		{ "EVT008: evt_tree_debug", ts_tree_debug, NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("evtree tree debug test",
-					evt_tree_debug, NULL, NULL);
-}
-
-static int
-run_drain_test(void)
-{
-	static const struct CMUnitTest evt_drain[] = {
-		{ "EVT009: evt_drain", ts_drain, NULL, NULL},
-		{ NULL, NULL, NULL, NULL }
-	};
-
-	return cmocka_run_group_tests_name("evtree drain test",
-					   evt_drain, NULL, NULL);
-}
 
 static void
 test_evt_outer_punch(void **state)
@@ -2339,50 +2237,50 @@ static struct option ts_ops[] = {
 static int
 ts_cmd_run(char opc, char *args)
 {
-	int	rc = 0;
+	int	 rc = 0;
+	void	 **st = NULL;
 
 	tst_fn_val.optval = args;
 	tst_fn_val.input = true;
 
 	switch (opc) {
 	case 'C':
-		rc = run_create_test();
+		ts_open_create(st);
 		break;
 	case 'D':
-		rc = run_destroy_test();
+		ts_close_destroy(st);
 		break;
 	case 'o':
 		tst_fn_val.input = false;
 		tst_fn_val.optval = NULL;
-		rc = run_create_test();
+		ts_open_create(st);
 		break;
 	case 'c':
 		tst_fn_val.input = false;
-		rc = run_destroy_test();
+		ts_close_destroy(st);
 		break;
 	case 'a':
-		rc = run_add_test();
+		ts_add_rect(st);
 		break;
 	case 'm':
-		rc = run_many_add_test();
+		ts_many_add(st);
 		break;
 	case 'e':
-		rc = run_drain_test();
+		ts_drain(st);
 		break;
 	case 'f':
-		rc = run_find_rect_test();
+		ts_find_rect(st);
 		break;
 	case 'l':
-		rc = run_list_rect_test();
+		ts_list_rect(st);
 		break;
 	case 'd':
-		rc = run_delete_rect_test();
+		ts_delete_rect(st);
 		break;
 	case 'b':
-		rc = run_tree_debug_test();
+		ts_tree_debug(st);
 		break;
 	case 't':
-		rc = run_internal_tests();
 		break;
 	case 's':
 		if (strcasecmp(args, "soff") == 0)
@@ -2395,10 +2293,35 @@ ts_cmd_run(char opc, char *args)
 		rc = 0;
 		break;
 	}
-	if (rc != 0)
-		D_PRINT("opc=%d failed with rc="DF_RC"\n", opc, DP_RC(rc));
-
+	if(st != NULL) {
+		rc = -1;
+	}
 	return rc;
+}
+
+static void
+ts_group(void ** state){
+	int	opc = 0;
+	while((opc = getopt_long(test_group_stop-test_group_start+1,
+				 test_group_args+test_group_start,
+				 "C:a:m:e:f:g:d:b:Docl::ts",
+				 ts_ops, NULL)) != -1){
+		ts_cmd_run(opc, optarg);
+	}
+}
+
+static int
+run_cmd_line_test(char* test_name, char** args, int start_idx, int stop_idx)
+{
+	const struct CMUnitTest evt_test[] = {
+		{ test_name, ts_group, NULL, NULL},
+	};
+
+	test_group_args = args;
+	test_group_start = start_idx;
+	test_group_stop = stop_idx;
+
+	return cmocka_run_group_tests_name("Group of tests", evt_test, NULL, NULL);
 }
 
 int
@@ -2406,6 +2329,10 @@ main(int argc, char **argv)
 {
 	struct timeval	tv;
 	int		rc;
+	int		j;
+	int		start_idx;
+	char		*test_name;
+	int 		stop_idx;
 
 	d_register_alt_assert(mock_assert);
 
@@ -2438,13 +2365,25 @@ main(int argc, char **argv)
 		goto out;
 	}
 
-	while ((rc = getopt_long(argc, argv, "C:a:m:e:f:g:d:b:Docl::ts:",
-				 ts_ops, NULL)) != -1) {
-		rc = ts_cmd_run(rc, optarg);
-		if (rc != 0)
-			goto out;
+	/* First, execute Internal tests in the command */
+	for(j=0; j<argc;j++){
+		if(strcmp(argv[j],"-t") == 0 ) {
+			rc = run_internal_tests();
+			if (rc != 0)
+				D_PRINT("Internal tests failed with rc="DF_RC"\n", DP_RC(rc));
+		}
 	}
-	rc = 0;
+	
+	/* Execute the sequence of tests */
+	stop_idx = argc-1;
+	if(strcmp(argv[1], "--start-test") != 0) {
+		start_idx = 0;
+		test_name = "Evt_ctl testing tool";
+	} else {
+		start_idx = 2;
+		test_name = argv[start_idx];
+	}
+	rc = run_cmd_line_test(test_name, argv, start_idx, stop_idx);
  out:
 	daos_debug_fini();
 	rc += utest_utx_destroy(ts_utx);


### PR DESCRIPTION
PR's text:
```
In order to clean up tests results, it was changed the usage of
cmocka for tests execution.

This commit implements the execution of a sequence of tests in a
single cmocka instance, instead of a cmocka instance per argument.

For this, a --start-test prameter is used to define the name of the
cmocka exetuion. If this parameter is not provided, then a default
test name is used.

Signed-off-by: Marcela Rosales <marcela.a.rosales.jimenez@intel.com>
```

link to original PR: `https://github.com/daos-stack/daos/pull/2315`