### PR TITLE
DAOS-3629 test: List containers with daos command

### DIFF
--- a/src/tests/ftest/container/list_containers.py
+++ b/src/tests/ftest/container/list_containers.py
@@ -39,6 +39,12 @@ class ListContainerTest(TestWithServers):
 
     :avocado: recursive
     """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize member."""
+        super(ListContainerTest, self).__init__(*args, **kwargs)
+        self.daos_cmd = None
+
     def verify_uuids(self, pool_uuid, service_replicas, expected_uuids):
         """Call daos pool list-cont to list the containers in the given pool
         UUID and verify the output against the given expected container UUIDs

--- a/src/tests/ftest/container/list_containers.py
+++ b/src/tests/ftest/container/list_containers.py
@@ -1,0 +1,120 @@
+#!/usr/bin/python
+'''
+  (C) Copyright 2018-2020 Intel Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+  The Government's rights to use, modify, reproduce, release, perform, display,
+  or disclose this software are subject to the terms of the Apache License as
+  provided in Contract No. B609815.
+  Any reproduction of computer software, computer software documentation, or
+  portions thereof marked with this legend must also reproduce the markings.
+'''
+from apricot import TestWithServers
+from dmg_utils import get_pool_uuid_service_replicas_from_stdout
+from daos_utils import DaosCommand
+
+
+class ListContainerTest(TestWithServers):
+    """
+    Test Class Description:
+        Tests daos pool list-cont. Test the following cases.
+        1. Create 1 container, list, and verify the listed container UUID
+            matches the UUID returned when created.
+        2. Create 1 more container and verify list; 2 total containers
+        3. Create 98 more containers and verify list; 100 total containers
+        4. Create 2 additional pools and create 10 containers in each pool.
+        Verify the container UUIDs in these 2 new pools.
+
+    :avocado: recursive
+    """
+    def verify_uuids(self, pool_uuid, service_replicas, expected_uuids):
+        """Call daos pool list-cont to list the containers in the given pool
+        UUID and verify the output against the given expected container UUIDs
+
+        Args:
+            pool_uuid (String): Pool UUID to get the list of containers
+            service_replicas (String): Service replicas. If there are multiple,
+                they're separated by comma like 1,2,3
+            expected_uuids (List of string): Expected container UUIDs
+        """
+        expected_uuids.sort()
+        # daos pool list-cont returns the date, host name, and container UUID
+        # as below:
+        # 03/31-21:32:24.53 wolf-3 2f69b198-8478-472e-b6c8-02a451f4de1b
+        list_stdout = self.daos_cmd.pool_list_cont(
+            pool_uuid, service_replicas).stdout
+        actual_uuids = []
+        lines = list_stdout.splitlines()
+        for cont_info in lines:
+            actual_uuids.append(cont_info.split()[2])
+        actual_uuids.sort()
+        self.assertEqual(expected_uuids, actual_uuids)
+
+    def test_list_container(self):
+        """Jira ID: DAOS-3629
+
+        Test Description:
+            Test daos pool list-cont
+
+        Use Cases:
+            See test cases in the class description.
+
+        :avocado: tags=all,container,full_regression,list_containers
+        """
+        # 1. Create 1 container and list
+        expected_uuids1 = []
+        stdoutput = self.get_dmg_command().pool_create(scm_size="150MB").stdout
+        uuid1, service_replicas1 = \
+            get_pool_uuid_service_replicas_from_stdout(stdoutput)
+        self.daos_cmd = DaosCommand(self.bin)
+        create_stdout = self.daos_cmd.container_create(
+            pool=uuid1, svc=service_replicas1).stdout
+        expected_uuids1.append(create_stdout.split()[3])
+        self.verify_uuids(uuid1, service_replicas1, expected_uuids1)
+
+        # 2. Create 1 more container and list; 2 total
+        create_stdout = self.daos_cmd.container_create(
+            pool=uuid1, svc=service_replicas1).stdout
+        expected_uuids1.append(create_stdout.split()[3])
+        self.verify_uuids(uuid1, service_replicas1, expected_uuids1)
+
+        # 3. Create 98 more containers and list; 100 total
+        for _ in range(98):
+            create_stdout = self.daos_cmd.container_create(
+                pool=uuid1, svc=service_replicas1).stdout
+            expected_uuids1.append(create_stdout.split()[3])
+        self.verify_uuids(uuid1, service_replicas1, expected_uuids1)
+
+        # 4. Create 2 additional pools and create 10 containers in each pool
+        stdoutput = self.get_dmg_command().pool_create(scm_size="150MB").stdout
+        uuid2, service_replicas2 = \
+            get_pool_uuid_service_replicas_from_stdout(stdoutput)
+        stdoutput = self.get_dmg_command().pool_create(scm_size="150MB").stdout
+        uuid3, service_replicas3 = \
+            get_pool_uuid_service_replicas_from_stdout(stdoutput)
+        # Create 10 containers in pool 2 and verify
+        expected_uuids2 = []
+        for _ in range(10):
+            create_stdout = self.daos_cmd.container_create(
+                pool=uuid2, svc=service_replicas2).stdout
+            expected_uuids2.append(create_stdout.split()[3])
+        self.verify_uuids(uuid2, service_replicas2, expected_uuids2)
+        # Create 10 containers in pool 3 and verify
+        expected_uuids3 = []
+        for _ in range(10):
+            create_stdout = self.daos_cmd.container_create(
+                pool=uuid3, svc=service_replicas3).stdout
+            expected_uuids3.append(create_stdout.split()[3])
+        self.verify_uuids(uuid3, service_replicas3, expected_uuids3)

--- a/src/tests/ftest/container/list_containers.yaml
+++ b/src/tests/ftest/container/list_containers.yaml
@@ -1,0 +1,6 @@
+hosts:
+  test_servers:
+    - server-A
+timeout: 600
+server_config:
+  name: daos_server

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -468,10 +468,9 @@ class DaosCommand(CommandWithSubCommand):
         """Query a pool.
 
         Args:
-            pool ([type]): [description]
-            sys_name ([type], optional): [description]. Defaults to None.
-            svc ([type], optional): [description]. Defaults to None.
-            sys ([type], optional): [description]. Defaults to None.
+            pool (String): Pool UUID.
+            sys_name (String, optional): System name. Defaults to None.
+            svc (String, optional): Pool service replicas. Defaults to None.
             env (dict, optional): dictionary of environment variable names and
                 values (EnvironmentVariables). Defaults to None.
 
@@ -499,15 +498,18 @@ class DaosCommand(CommandWithSubCommand):
 
         Args:
             pool (str): UUID of the pool in which to create the container
-            sys_name (str, optional): [description]. Defaults to None.
+            sys_name (str, optional): System name.. Defaults to None.
             svc (str, optional): the pool service replicas, e.g. '1,2,3'.
                 Defaults to None.
-            cont (str, optional): [description]. Defaults to None.
-            path (str, optional): [description]. Defaults to None.
+            cont (str, optional): Container UUID. Defaults to None.
+            path (str, optional): Container namespace path. Defaults to None.
             cont_type (str, optional): the type of container to create. Defaults
                 to None.
             oclass (str, optional): object class. Defaults to None.
-            chunk_size ([type], optional): [description]. Defaults to None.
+            chunk_size ([type], optional): chunk size of files created.
+                Supports suffixes:
+                K (KB), M (MB), G (GB), T (TB), P (PB), E (EB). Defaults to
+                None.
             env (dict, optional): dictionary of environment variable names and
                 values (EnvironmentVariables). Defaults to None.
 
@@ -529,5 +531,31 @@ class DaosCommand(CommandWithSubCommand):
         self.sub_command_class.sub_command_class.type.value = cont_type
         self.sub_command_class.sub_command_class.oclass.value = oclass
         self.sub_command_class.sub_command_class.chunk_size.value = chunk_size
+        self.env = env
+        return self._get_result()
+
+    def pool_list_cont(self, pool, svc, sys_name=None, env=None):
+        """List containers in the given pool.
+
+        Args:
+            pool (String): Pool UUID
+            svc (String, optional): Service replicas. If there are multiple,
+                numbers are separated by comma like 1,2,3
+            sys_name (String, optional): System name. Defaults to None.
+            env (dict, optional): dictionary of environment variable names and
+                values (EnvironmentVariables). Defaults to None.
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: Returned if the command fails.
+        """
+        self.set_sub_command("pool")
+        self.sub_command_class.set_sub_command("list-containers")
+        self.sub_command_class.sub_command_class.pool.value = pool
+        self.sub_command_class.sub_command_class.svc.value = svc
+        self.sub_command_class.sub_command_class.sys_name.value = sys_name
         self.env = env
         return self._get_result()

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -529,7 +529,7 @@ class DmgCommand(CommandWithSubCommand):
         the corresponding user/group name string.
 
         Args:
-            scm_size (int): SCM pool size to create.
+            scm_size (str): SCM pool size to create.
             uid (object, optional): User ID with privileges. Defaults to None.
             gid (object, otional): Group ID with privileges. Defaults to None.
             nvme_size (str, optional): NVMe size. Defaults to None.


### PR DESCRIPTION
PR's text:
```
Test steps
1. Create 1 container and list
2. Create 1 more container and list; 2 total
3. Create 98 more containers and list; 100 total
4. Create 2 additional pools and create 10 containers in each pool

Verify the container UUIDs from daos pool list-cont
againt the UUIDs returned when the containers were created

Fixed comments in the methods in daos_utils.py

Signed-off-by: Makito Kano <makito.kano@intel.com>
```

link to original PR: `https://github.com/daos-stack/daos/pull/2325`